### PR TITLE
build(macos): adapt configuration and build system for macOS

### DIFF
--- a/deps/diff/config.h.old
+++ b/deps/diff/config.h.old
@@ -18,26 +18,26 @@
 #define HAVE_ARC4RANDOM 1
 #define HAVE_CAPSICUM 0
 #define HAVE_ERR 1
-#define HAVE_EXPLICIT_BZERO 1
-#define HAVE_GETPROGNAME 0
+#define HAVE_EXPLICIT_BZERO 0
+#define HAVE_GETPROGNAME 1
 #define HAVE_INFTIM 0
 #define HAVE_MD5 0
 #define HAVE_MEMMEM 1
-#define HAVE_MEMRCHR 1
-#define HAVE_MEMSET_S 0
+#define HAVE_MEMRCHR 0
+#define HAVE_MEMSET_S 1
 #define HAVE_PATH_MAX 1
 #define HAVE_PLEDGE 0
-#define HAVE_PROGRAM_INVOCATION_SHORT_NAME 1
-#define HAVE_REALLOCARRAY 1
+#define HAVE_PROGRAM_INVOCATION_SHORT_NAME 0
+#define HAVE_REALLOCARRAY 0
 #define HAVE_RECALLOCARRAY 0
-#define HAVE_SANDBOX_INIT 0
-#define HAVE_SECCOMP_FILTER 1
-#define HAVE_SOCK_NONBLOCK 1
+#define HAVE_SANDBOX_INIT 1
+#define HAVE_SECCOMP_FILTER 0
+#define HAVE_SOCK_NONBLOCK 0
 #define HAVE_STRLCAT 1
 #define HAVE_STRLCPY 1
 #define HAVE_STRNDUP 1
 #define HAVE_STRNLEN 1
-#define HAVE_STRTONUM 0
+#define HAVE_STRTONUM 1
 #define HAVE_SYSTRACE 0
 #define HAVE_ZLIB 1
 #define HAVE___PROGNAME 1
@@ -55,7 +55,7 @@ extern void MD5Pad(MD5_CTX *);
 extern void MD5Transform(u_int32_t [4], const u_int8_t [MD5_BLOCK_LENGTH]);
 extern char *MD5End(MD5_CTX *, char *);
 extern void MD5Final(u_int8_t [MD5_DIGEST_LENGTH], MD5_CTX *);
-#define SECCOMP_AUDIT_ARCH AUDIT_ARCH_X86_64
-extern const char *getprogname(void);
+extern void explicit_bzero(void *, size_t);
+void *memrchr(const void *b, int, size_t);
+extern void *reallocarray(void *, size_t, size_t);
 extern void *recallocarray(void *, size_t, size_t, size_t);
-extern long long strtonum(const char *, long long, long long, const char **);

--- a/deps/diff/config.log.old
+++ b/deps/diff/config.log.old
@@ -1,0 +1,179 @@
+configure.local: reading...
+HAVE___PROGNAME=1
+
+arc4random: testing...
+cc  -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wno-unused-parameter  -Wno-unused -Werror -DTEST_ARC4RANDOM  -o test-arc4random tests.c 
+arc4random: cc succeeded
+arc4random: yes
+
+capsicum: testing...
+cc  -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wno-unused-parameter  -Wno-unused -Werror -DTEST_CAPSICUM  -o test-capsicum tests.c 
+tests.c:20:10: fatal error: 'sys/capsicum.h' file not found
+   20 | #include <sys/capsicum.h>
+      |          ^~~~~~~~~~~~~~~~
+1 error generated.
+capsicum: cc failed with 1
+
+err: testing...
+cc  -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wno-unused-parameter  -Wno-unused -Werror -DTEST_ERR  -o test-err tests.c 
+err: cc succeeded
+test-err: 1. warnx
+test-err: 2. warn: Undefined error: 0
+test-err: 3. err: Undefined error: 0
+err: yes
+
+explicit_bzero: testing...
+cc  -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wno-unused-parameter  -Wno-unused -Werror -DTEST_EXPLICIT_BZERO  -o test-explicit_bzero tests.c 
+tests.c:66:2: error: call to undeclared function 'explicit_bzero'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
+   66 |         explicit_bzero(foo, sizeof(foo));
+      |         ^
+1 error generated.
+explicit_bzero: cc failed with 1
+
+getprogname: testing...
+cc  -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wno-unused-parameter  -Wno-unused -Werror -DTEST_GETPROGNAME  -o test-getprogname tests.c 
+getprogname: cc succeeded
+getprogname: yes
+
+INFTIM: testing...
+cc  -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wno-unused-parameter  -Wno-unused -Werror -DTEST_INFTIM  -o test-INFTIM tests.c 
+tests.c:93:48: error: use of undeclared identifier 'INFTIM'
+   93 |         printf("INFTIM is defined to be %ld\n", (long)INFTIM);
+      |                                                       ^
+1 error generated.
+INFTIM: cc failed with 1
+
+md5: testing...
+cc  -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wno-unused-parameter  -Wno-unused -Werror -DTEST_MD5  -o test-md5 tests.c 
+tests.c:99:10: fatal error: 'md5.h' file not found
+   99 | #include <md5.h>
+      |          ^~~~~~~
+1 error generated.
+md5: cc failed with 1
+
+memmem: testing...
+cc  -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wno-unused-parameter  -Wno-unused -Werror -DTEST_MEMMEM  -o test-memmem tests.c 
+memmem: cc succeeded
+memmem: yes
+
+memrchr: testing...
+cc  -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wno-unused-parameter  -Wno-unused -Werror -DTEST_MEMRCHR  -o test-memrchr tests.c 
+tests.c:134:8: error: call to undeclared function 'memrchr'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
+  134 |         res = memrchr(buf, 'a', strlen(buf));
+      |               ^
+tests.c:134:8: note: did you mean 'memchr'?
+/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_string.h:74:3: note: 'memchr' declared here
+   74 |                 memchr(const void *_LIBC_SIZE(__n) __s, int __c, size_t __n);
+      |                 ^
+tests.c:134:6: error: incompatible integer to pointer conversion assigning to 'void *' from 'int' [-Wint-conversion]
+  134 |         res = memrchr(buf, 'a', strlen(buf));
+      |             ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+2 errors generated.
+memrchr: cc failed with 1
+
+memset_s: testing...
+cc  -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wno-unused-parameter  -Wno-unused -Werror -DTEST_MEMSET_S  -o test-memset_s tests.c 
+memset_s: cc succeeded
+memset_s: yes
+
+PATH_MAX: testing...
+cc  -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wno-unused-parameter  -Wno-unused -Werror -DTEST_PATH_MAX  -o test-PATH_MAX tests.c 
+PATH_MAX: cc succeeded
+PATH_MAX is defined to be 1024
+PATH_MAX: yes
+
+pledge: testing...
+cc  -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wno-unused-parameter  -Wno-unused -Werror -DTEST_PLEDGE  -o test-pledge tests.c 
+tests.c:186:11: error: call to undeclared function 'pledge'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
+  186 |         return !!pledge("stdio", NULL);
+      |                  ^
+1 error generated.
+pledge: cc failed with 1
+
+program_invocation_short_name: testing...
+cc  -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wno-unused-parameter  -Wno-unused -Werror -DTEST_PROGRAM_INVOCATION_SHORT_NAME  -o test-program_invocation_short_name tests.c 
+tests.c:197:10: error: use of undeclared identifier 'program_invocation_short_name'
+  197 |         return !program_invocation_short_name;
+      |                 ^
+1 error generated.
+program_invocation_short_name: cc failed with 1
+
+reallocarray: testing...
+cc  -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wno-unused-parameter  -Wno-unused -Werror -DTEST_REALLOCARRAY  -o test-reallocarray tests.c 
+tests.c:206:10: error: call to undeclared function 'reallocarray'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
+  206 |         return !reallocarray(NULL, 2, 2);
+      |                 ^
+1 error generated.
+reallocarray: cc failed with 1
+
+recallocarray: testing...
+cc  -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wno-unused-parameter  -Wno-unused -Werror -DTEST_RECALLOCARRAY  -o test-recallocarray tests.c 
+tests.c:215:10: error: call to undeclared function 'recallocarray'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
+  215 |         return !recallocarray(NULL, 0, 2, 2);
+      |                 ^
+1 error generated.
+recallocarray: cc failed with 1
+
+sandbox_init: testing...
+cc  -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wno-unused-parameter  -Wno-unused -Werror -DTEST_SANDBOX_INIT -Wno-deprecated -o test-sandbox_init tests.c 
+sandbox_init: cc succeeded
+sandbox_init: yes
+
+seccomp-filter: testing...
+cc  -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wno-unused-parameter  -Wno-unused -Werror -DTEST_SECCOMP_FILTER  -o test-seccomp-filter tests.c 
+tests.c:234:10: fatal error: 'sys/prctl.h' file not found
+  234 | #include <sys/prctl.h>
+      |          ^~~~~~~~~~~~~
+1 error generated.
+seccomp-filter: cc failed with 1
+
+SOCK_NONBLOCK: testing...
+cc  -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wno-unused-parameter  -Wno-unused -Werror -DTEST_SOCK_NONBLOCK  -o test-SOCK_NONBLOCK tests.c 
+tests.c:257:34: error: use of undeclared identifier 'SOCK_NONBLOCK'
+  257 |         socketpair(AF_UNIX, SOCK_STREAM|SOCK_NONBLOCK, 0, fd);
+      |                                         ^
+1 error generated.
+SOCK_NONBLOCK: cc failed with 1
+
+strlcat: testing...
+cc  -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wno-unused-parameter  -Wno-unused -Werror -DTEST_STRLCAT  -o test-strlcat tests.c 
+strlcat: cc succeeded
+strlcat: yes
+
+strlcpy: testing...
+cc  -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wno-unused-parameter  -Wno-unused -Werror -DTEST_STRLCPY  -o test-strlcpy tests.c 
+strlcpy: cc succeeded
+strlcpy: yes
+
+strndup: testing...
+cc  -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wno-unused-parameter  -Wno-unused -Werror -DTEST_STRNDUP  -o test-strndup tests.c 
+strndup: cc succeeded
+strndup: yes
+
+strnlen: testing...
+cc  -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wno-unused-parameter  -Wno-unused -Werror -DTEST_STRNLEN  -o test-strnlen tests.c 
+strnlen: cc succeeded
+strnlen: yes
+
+strtonum: testing...
+cc  -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wno-unused-parameter  -Wno-unused -Werror -DTEST_STRTONUM  -o test-strtonum tests.c 
+strtonum: cc succeeded
+strtonum: yes
+
+systrace: testing...
+cc  -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wno-unused-parameter  -Wno-unused -Werror -DTEST_SYSTRACE  -o test-systrace tests.c 
+tests.c:354:10: fatal error: 'dev/systrace.h' file not found
+  354 | #include <dev/systrace.h>
+      |          ^~~~~~~~~~~~~~~~
+1 error generated.
+systrace: cc failed with 1
+
+zlib: testing...
+cc  -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wno-unused-parameter  -Wno-unused -Werror -DTEST_ZLIB  -o test-zlib tests.c -lz
+zlib: cc succeeded
+zlib: yes
+
+__progname: manual (HAVE___PROGNAME=1)
+
+config.h: written
+Makefile.configure: written

--- a/makefile
+++ b/makefile
@@ -22,11 +22,18 @@ SHELL = /bin/sh
 RM ?= rm -f
 FIND ?= find
 
-INCLUDES=-Ilibstrophe -Ideps/lmdbxx -Ideps -Isrc -I. \
+INCLUDES=-Ideps/lmdbxx -Ideps -Isrc -I. \
 	 $(shell xml2-config --cflags) \
+	 $(shell pkg-config --cflags libstrophe) \
+	 -I$(shell pkg-config --variable=includedir weechat) \
+	 $(shell pkg-config --cflags fmt) \
+	 $(shell pkg-config --cflags openssl) \
 	 $(shell pkg-config --cflags gpgme) \
 	 $(shell pkg-config --cflags libsignal-protocol-c) \
 	 $(shell pkg-config --cflags libomemo-c)
+ifeq ($(UNAME_S),Darwin)
+INCLUDES+=-I$(HOMEBREW_PREFIX)/include
+endif
 ifeq ($(UNAME_S),Darwin)
 DWARF_FLAG := -g
 else
@@ -71,10 +78,13 @@ endif
 LDFLAGS+=$(DBGLDFLAGS) \
 	 -std=c++23 $(DWARF_FLAG) \
 	 $(DBGCFLAGS)
-LDLIBS=-lstrophe \
+ifeq ($(UNAME_S),Darwin)
+LDFLAGS+=-L$(HOMEBREW_PREFIX)/lib
+endif
+LDLIBS=$(shell pkg-config --libs libstrophe) \
 	   -lpthread \
 	   -lcurl \
-	   -lcrypto \
+	   $(shell pkg-config --libs libcrypto) \
 	   $(shell xml2-config --libs) \
 	   $(shell pkg-config --libs gpgme) \
 		   $(shell pkg-config --libs libomemo-c) \
@@ -193,14 +203,14 @@ sexp/sexp.a: sexp/parser.o sexp/lexer.o sexp/driver.o
 sexp/parser.o: sexp/parser.yy
 	cd sexp && bison -t -d -v parser.yy
 ifneq ($(IS_CLANG),)
-	$(CXX) $(CPPFLAGS) -fvisibility=default -Wno-unused-variable -c sexp/parser.tab.cc -o $@
+	$(CXX) $(CPPFLAGS) -fvisibility=default -Wno-unused-variable -Wno-unused-but-set-variable -c sexp/parser.tab.cc -o $@
 else
 	$(CXX) $(CPPFLAGS) -fvisibility=default -Wno-unused-but-set-variable -c sexp/parser.tab.cc -o $@
 endif
 
 sexp/lexer.o: sexp/lexer.l
 	cd sexp && flex -d --outfile=lexer.yy.cc lexer.l
-	$(CXX) $(CPPFLAGS) -fvisibility=default -c sexp/lexer.yy.cc -o $@
+	$(CXX) $(CPPFLAGS) -fvisibility=default -Wno-sign-compare -c sexp/lexer.yy.cc -o $@
 
 sexp/driver.o: sexp/driver.cpp
 	$(CXX) $(CPPFLAGS) -fvisibility=default -c $< -o $@

--- a/src/command/presence.inl
+++ b/src/command/presence.inl
@@ -128,7 +128,7 @@ int command__mood(const void *pointer, void *data,
             "xmpp.picker.mood",
             "Select a mood  (XEP-0107)",
             std::move(entries),
-            [ptr_account, buf = buffer](const std::string &selected) {
+            [buf = buffer](const std::string &selected) {
                 auto cmd = fmt::format("/mood {}", selected);
                 weechat_command(buf, cmd.c_str());
             },
@@ -323,7 +323,7 @@ int command__activity(const void *pointer, void *data,
             "xmpp.picker.activity",
             "Select an activity  (XEP-0108)",
             std::move(entries),
-            [ptr_account, buf = buffer](const std::string &selected) {
+            [buf = buffer](const std::string &selected) {
                 auto cmd = fmt::format("/activity {}", selected);
                 weechat_command(buf, cmd.c_str());
             },

--- a/src/command/roster.inl
+++ b/src/command/roster.inl
@@ -349,7 +349,7 @@ int command__roster(const void *pointer, void *data,
             "xmpp.picker.roster",
             "Open chat with contact  (roster)",
             std::move(entries),
-            [ptr_account, buf = buffer](const std::string &selected) {
+            [buf = buffer](const std::string &selected) {
                 auto cmd = fmt::format("/open {}", selected);
                 weechat_command(buf, cmd.c_str());
             },

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -138,11 +138,12 @@ void weechat::user::nicklist_add(weechat::account *account,
     if (this->profile.affiliation.has_value() && this->profile.affiliation.value() == "owner")
         group = "~";
     ptr_group = weechat_nicklist_search_group(ptr_buffer, nullptr, group);
+    auto nick_colour = get_colour_for_nicklist();
     weechat_nicklist_add_nick(ptr_buffer, ptr_group,
                               name,
                               this->is_away ?
                               "weechat.color.nicklist_away" :
-                              get_colour_for_nicklist().data(),
+                              nick_colour.data(),
                               group,
                               "bar_fg",
                               1);
@@ -176,9 +177,10 @@ void weechat::user::nicklist_set_color(weechat::account *account,
     struct t_gui_nick *ptr_nick = weechat_nicklist_search_nick(ptr_buffer, nullptr, name);
     if (ptr_nick)
     {
+        auto nick_colour = get_colour_for_nicklist();
         const char *color = this->is_away
             ? "weechat.color.nicklist_away"
-            : get_colour_for_nicklist().data();
+            : nick_colour.data();
         weechat_nicklist_nick_set(ptr_buffer, ptr_nick, "color", color);
     }
 }

--- a/test.mk
+++ b/test.mk
@@ -2,7 +2,7 @@
 # vim: set noexpandtab:
 
 ifeq ($(UNAME_S),Darwin)
-TEST_LDFLAGS := -Wl,-undefined,dynamic_lookup -Wl,-rpath,$(PWD)
+TEST_LDFLAGS := -Wl,-undefined,dynamic_lookup -Wl,-rpath,$(PWD)/tests
 else
 TEST_LDFLAGS := -Wl,--allow-shlib-undefined -Wl,-rpath,$$PWD
 endif
@@ -20,11 +20,15 @@ debug: xmpp.so
 endif
 
 tests/xmpp.cov.so: $(COVS) $(DEPS) $(HDRS)
+ifeq ($(UNAME_S),Darwin)
+	$(CXX) --coverage $(SHARED_FLAG) $(LDFLAGS) -Wl,-install_name,@rpath/xmpp.cov.so -o tests/xmpp.cov.so $(AS_NEEDED) $(COVS) $(DEPS) $(LDLIBS)
+else
 	$(CXX) --coverage $(SHARED_FLAG) $(LDFLAGS) -o tests/xmpp.cov.so $(AS_NEEDED) $(COVS) $(DEPS) $(LDLIBS)
+endif
 
 tests/run: $(COVS) tests/main.cc tests/xmpp.cov.so $(wildcard tests/*.inl)
 	cd tests && $(CXX) $(CPPFLAGS) $(LDFLAGS) -o run main.cc $(patsubst %,../%,$(DEPS)) $(LDLIBS) \
-		$(TEST_LDFLAGS) $(PWD)/xmpp.cov.so
+		$(TEST_LDFLAGS) $(PWD)/tests/xmpp.cov.so
 
 .PHONY: test
 test: tests/run


### PR DESCRIPTION
- Update feature detection macros in config.h based on macOS environment.
- Add config.log from macOS configuration tests.
- Modify makefile to use pkg-config for dependencies and handle Homebrew paths on macOS.
- Simplify lambda captures in command handlers.
- Adjust nicklist color handling in user.cpp.
- Update test.mk for macOS-specific linking flags.